### PR TITLE
fix main entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ except ImportError:
 else:
     params['entry_points'] = {
         'console_scripts': [
-            "nitpycker = nitpycker:run"
+            "nitpycker = nitpycker:main"
         ]
     }
 


### PR DESCRIPTION
`run` is referenced in `setup.py` but it is not declared in `nitpycker/__init__.py`.

btw, what's the use of `nitpycker/__main__.py`? It seems to be related.
