### PR TITLE
gitgnore: add vim, parallel coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .idea
 *.pyc
 htmlcov
-.coverage
+.coverage*
 docs/build/*
 NitPycker.egg-info
 dist
+.*.sw?


### PR DESCRIPTION
That's pretty much it.
- parralel coverage have their own extension
- bit of magic for vim swap files, but cover most cases.
